### PR TITLE
Improve game edit page.

### DIFF
--- a/src/AdrenalineGamesEditor/App.xaml
+++ b/src/AdrenalineGamesEditor/App.xaml
@@ -2,7 +2,8 @@
 <Application x:Class="MrCapitalQ.AdrenalineGamesEditor.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:shared="using:MrCapitalQ.AdrenalineGamesEditor.Shared">
+             xmlns:shared="using:MrCapitalQ.AdrenalineGamesEditor.Shared"
+             xmlns:converters="using:CommunityToolkit.WinUI.Converters">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -15,6 +16,12 @@
             <Thickness x:Key="CommandBarBorderThicknessOpen">0</Thickness>
 
             <shared:ItemClickedParameterConverter x:Key="ItemClickedParameterConverter" />
+            <converters:EmptyStringToObjectConverter x:Key="IsEmptyStringConverter"
+                                                     EmptyValue="True"
+                                                     NotEmptyValue="False" />
+            <converters:EmptyStringToObjectConverter x:Key="IsNotEmptyStringConverter"
+                                                     EmptyValue="False"
+                                                     NotEmptyValue="True" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/AdrenalineGamesEditor/Games/GameEditPage.xaml
+++ b/src/AdrenalineGamesEditor/Games/GameEditPage.xaml
@@ -6,6 +6,7 @@
       xmlns:controls="using:CommunityToolkit.WinUI.Controls"
       xmlns:core="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
+      xmlns:ui="using:CommunityToolkit.WinUI"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       mc:Ignorable="d">
@@ -13,43 +14,126 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition />
         </Grid.RowDefinitions>
-        <CommandBar IsOpen="False"
+
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="PageStates">
+                <VisualState x:Name="ContentLoaded" />
+                <VisualState x:Name="ContentLoading">
+                    <VisualState.StateTriggers>
+                        <ui:IsEqualStateTrigger Value="{x:Bind _viewModel.IsLoading, Mode=OneWay}"
+                                                To="True" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="CommandBar.Visibility"
+                                Value="Collapsed" />
+                        <Setter Target="PageContent.Visibility"
+                                Value="Collapsed" />
+                        <Setter Target="LoadingIndicator.Visibility"
+                                Value="Visible" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+            <VisualStateGroup x:Name="ExePathStates">
+                <VisualState x:Name="DefaultExePathState" />
+                <VisualState x:Name="CustomExePathOnly">
+                    <VisualState.StateTriggers>
+                        <ui:CompareStateTrigger Comparison="LessThan"
+                                                Value="{x:Bind _viewModel.ExePathOptions.Count, Mode=OneWay}"
+                                                To="2" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="PackageExePaths.Visibility"
+                                Value="Collapsed" />
+                        <Setter Target="CustomExeBox.Header"
+                                Value="Executable path" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="PackageExePathSelected">
+                    <VisualState.StateTriggers>
+                        <ui:IsNotEqualStateTrigger Value="{x:Bind _viewModel.SelectedExePathOption.Value.Length, Mode=OneWay}"
+                                                   To="0" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="ExePathDisplay.Visibility"
+                                Value="Visible" />
+                        <Setter Target="CustomExeBox.Visibility"
+                                Value="Collapsed" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+
+        <ProgressRing x:Name="LoadingIndicator"
+                      IsActive="True"
+                      Visibility="Collapsed"
+                      Grid.RowSpan="3" />
+
+        <CommandBar x:Name="CommandBar"
                     DefaultLabelPosition="Right"
                     VerticalContentAlignment="Center">
             <CommandBar.Content>
                 <TextBlock Text="{x:Bind _viewModel.Title, Mode=OneWay}"
                            Style="{StaticResource TitleTextBlockStyle}"
-                           Margin="12,0" />
+                           Margin="12,0"
+                           TextLineBounds="Tight" />
             </CommandBar.Content>
             <AppBarButton Icon="Save"
                           Label="Save"
-                          Command="{x:Bind _viewModel.SaveCommand}" />
+                          Command="{x:Bind _viewModel.SaveCommand}">
+                <AppBarButton.KeyboardAccelerators>
+                    <KeyboardAccelerator Key="S"
+                                         Modifiers="Control" />
+                </AppBarButton.KeyboardAccelerators>
+            </AppBarButton>
         </CommandBar>
 
-        <ScrollView Grid.Row="1">
+        <InfoBar IsOpen="{x:Bind _viewModel.CanAutoFix, Mode=OneWay}"
+                 Severity="Warning"
+                 Message="The installed location of this game or app's package has changed and new equivalent paths were found."
+                 Grid.Row="1">
+            <InfoBar.ActionButton>
+                <Button Content="Apply new paths"
+                        HorizontalAlignment="Right"
+                        Command="{x:Bind _viewModel.AutoFixCommand}" />
+            </InfoBar.ActionButton>
+        </InfoBar>
+
+        <ScrollView x:Name="PageContent"
+                    Grid.Row="2">
             <StackPanel Margin="16"
                         Spacing="16">
                 <StackPanel HorizontalAlignment="Center">
-                    <local:AdrenalineGameImage SourcePath="{x:Bind _viewModel.EffectiveImagePath, Mode=OneWay}"
-                                               Width="150"
-                                               Height="150"
-                                               CornerRadius="{StaticResource ControlCornerRadius}">
-                        <local:AdrenalineGameImage.ContextFlyout>
-                            <MenuFlyout>
-                                <MenuFlyoutItem Text="Copy image path"
-                                                Command="{x:Bind _viewModel.CopyImagePathCommand}" />
-                            </MenuFlyout>
-                        </local:AdrenalineGameImage.ContextFlyout>
-                    </local:AdrenalineGameImage>
+                    <Grid>
+                        <local:AdrenalineGameImage SourcePath="{x:Bind _viewModel.EffectiveImagePath, Mode=OneWay}"
+                                                   Width="150"
+                                                   Height="150"
+                                                   CornerRadius="{StaticResource ControlCornerRadius}">
+                            <local:AdrenalineGameImage.ContextFlyout>
+                                <MenuFlyout>
+                                    <MenuFlyoutItem Text="Copy image path"
+                                                    Command="{x:Bind _viewModel.CopyImagePathCommand}" />
+                                </MenuFlyout>
+                            </local:AdrenalineGameImage.ContextFlyout>
+                        </local:AdrenalineGameImage>
+
+                        <FontIcon Glyph="&#xE7BA;"
+                                  Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                                  Visibility="{x:Bind _viewModel.ImagePathRequiresAttention, Mode=OneWay}"
+                                  Margin="16,8"
+                                  VerticalAlignment="Top"
+                                  HorizontalAlignment="Right"
+                                  ToolTipService.ToolTip="Image path does not exist or cannot be accessed." />
+                    </Grid>
                     <CommandBar DefaultLabelPosition="Right">
                         <AppBarButton Icon="Edit"
                                       Label="Edit"
                                       Command="{x:Bind _viewModel.EditImageCommand}" />
                         <AppBarButton Icon="Clear"
                                       Label="Remove"
-                                      IsEnabled="{x:Bind _viewModel.HasImagePath, Mode=OneWay}">
+                                      IsEnabled="{x:Bind _viewModel.ImagePath, Mode=OneWay, Converter={StaticResource IsNotEmptyStringConverter}}">
                             <AppBarButton.Flyout>
                                 <Flyout x:Name="RemoveImageFlyout">
                                     <Flyout.FlyoutPresenterStyle>
@@ -80,28 +164,34 @@
                         </AppBarButton>
                     </CommandBar>
                 </StackPanel>
-                <TextBox Text="{x:Bind _viewModel.DisplayName, Mode=TwoWay}"
+                <TextBox Text="{x:Bind _viewModel.DisplayName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                          Header="Display name" />
-                <TextBox Text="{x:Bind _viewModel.Command, Mode=TwoWay}"
+                <TextBox Text="{x:Bind _viewModel.Command, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                          Header="Command" />
-                <StackPanel Spacing="8">
-                    <ComboBox ItemsSource="{x:Bind _viewModel.ExePathOptions, Mode=OneWay}"
-                              SelectedItem="{x:Bind _viewModel.SelectedExePathOption, Mode=TwoWay}"
-                              DisplayMemberPath="Display"
-                              Header="Executable path"
-                              HorizontalAlignment="Stretch" />
-                    <controls:SwitchPresenter Value="{x:Bind _viewModel.SelectedExePathOption.Value, Mode=OneWay}">
-                        <controls:Case IsDefault="True">
-                            <TextBlock Text="{x:Bind _viewModel.ExePath, Mode=OneWay}"
-                                       Style="{StaticResource CaptionTextBlockStyle}"
-                                       Foreground="{StaticResource TextFillColorSecondaryBrush}" />
-                        </controls:Case>
-                        <controls:Case Value="!CUSTOM!">
-                            <TextBox Text="{x:Bind _viewModel.ExePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                     TextWrapping="Wrap" />
-                        </controls:Case>
-                    </controls:SwitchPresenter>
-                </StackPanel>
+                <Grid>
+                    <StackPanel Spacing="8">
+                        <ComboBox x:Name="PackageExePaths"
+                                  ItemsSource="{x:Bind _viewModel.ExePathOptions, Mode=OneWay}"
+                                  SelectedItem="{x:Bind _viewModel.SelectedExePathOption, Mode=TwoWay}"
+                                  DisplayMemberPath="Display"
+                                  Header="Executable path"
+                                  HorizontalAlignment="Stretch" />
+                        <TextBlock x:Name="ExePathDisplay"
+                                   Text="{x:Bind _viewModel.ExePath, Mode=OneWay}"
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   Foreground="{StaticResource TextFillColorSecondaryBrush}"
+                                   Visibility="Collapsed" />
+                        <TextBox x:Name="CustomExeBox"
+                                 Text="{x:Bind _viewModel.ExePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                 TextWrapping="Wrap" />
+                    </StackPanel>
+                    <FontIcon Glyph="&#xE7BA;"
+                              Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                              Visibility="{x:Bind _viewModel.ExePathRequiresAttention, Mode=OneWay}"
+                              VerticalAlignment="Top"
+                              HorizontalAlignment="Right"
+                              ToolTipService.ToolTip="Executable path does not exist or cannot be accessed." />
+                </Grid>
             </StackPanel>
         </ScrollView>
     </Grid>

--- a/test/AdrenalineGamesEditor.Tests/Games/GameEditViewModelTests.cs
+++ b/test/AdrenalineGamesEditor.Tests/Games/GameEditViewModelTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Testing;
 using MrCapitalQ.AdrenalineGamesEditor.Core;
 using MrCapitalQ.AdrenalineGamesEditor.Core.Adrenaline;
 using MrCapitalQ.AdrenalineGamesEditor.Core.Apps;
+using MrCapitalQ.AdrenalineGamesEditor.Core.FileSystem;
 using MrCapitalQ.AdrenalineGamesEditor.Games;
 using MrCapitalQ.AdrenalineGamesEditor.Shared;
 using NSubstitute.ExceptionExtensions;
@@ -19,18 +20,29 @@ public class GameEditViewModelTests
     private readonly IMessenger _messenger = Substitute.For<IMessenger>();
     private readonly IFilePicker _filePicker = Substitute.For<IFilePicker>();
     private readonly IClipboardService _clipboardService = Substitute.For<IClipboardService>();
+    private readonly IDispatcherQueue _dispatcherQueue = Substitute.For<IDispatcherQueue>();
+    private readonly IPath _path = Substitute.For<IPath>();
     private readonly FakeLogger<GameEditViewModel> _logger = new();
 
     private readonly GameEditViewModel _viewModel;
 
     public GameEditViewModelTests()
     {
+        _dispatcherQueue.TryEnqueue(Arg.Any<Action>()).Returns(x =>
+        {
+            x.Arg<Action>().Invoke();
+            return true;
+        });
+        _path.Exists(Arg.Any<string>()).Returns(true);
+
         _viewModel = new GameEditViewModel(_packagedAppsService,
             _qualifiedFileResolver,
             _adrenalineGamesDataService,
             _messenger,
             _filePicker,
             _clipboardService,
+            _dispatcherQueue,
+            _path,
             _logger);
     }
 
@@ -45,8 +57,8 @@ public class GameEditViewModelTests
             null,
             @"Assets\Logo.png",
             true,
-            @"Game.exe",
-            ["gamelauncherhelper.exe", @"Game.exe"]);
+            "Game.exe",
+            ["gamelauncherhelper.exe", "Game.exe"]);
         var expectedExePath = Path.Combine(appInfo.InstalledPath, appInfo.ExecutablePath!);
         var expectedImagePath = Path.Combine(appInfo.InstalledPath, appInfo.Square150x150Logo!);
         var expectedOptions = appInfo.ExecutablePaths
@@ -63,6 +75,8 @@ public class GameEditViewModelTests
             _messenger,
             _filePicker,
             _clipboardService,
+            _dispatcherQueue,
+            _path,
             _logger,
             appUserModelId: appInfo.AppUserModelId);
 
@@ -77,6 +91,9 @@ public class GameEditViewModelTests
         Assert.Equal(viewModel.ExePathOptions.Single(x => x.Value == expectedExePath), viewModel.SelectedExePathOption);
         Assert.True(viewModel.IsManual);
         Assert.False(viewModel.IsHidden);
+        Assert.False(viewModel.CanAutoFix);
+        Assert.False(viewModel.ImagePathRequiresAttention);
+        Assert.False(viewModel.ExePathRequiresAttention);
     }
 
     [Fact]
@@ -107,6 +124,8 @@ public class GameEditViewModelTests
             _messenger,
             _filePicker,
             _clipboardService,
+            _dispatcherQueue,
+            _path,
             _logger,
             appUserModelId: appInfo.AppUserModelId);
 
@@ -121,6 +140,9 @@ public class GameEditViewModelTests
         Assert.Equal(GameEditViewModel.CustomExePathOption, viewModel.SelectedExePathOption);
         Assert.True(viewModel.IsManual);
         Assert.False(viewModel.IsHidden);
+        Assert.False(viewModel.CanAutoFix);
+        Assert.False(viewModel.ImagePathRequiresAttention);
+        Assert.False(viewModel.ExePathRequiresAttention);
     }
 
     [Fact]
@@ -132,6 +154,8 @@ public class GameEditViewModelTests
             _messenger,
             _filePicker,
             _clipboardService,
+            _dispatcherQueue,
+            _path,
             _logger,
             appUserModelId: "Package!App");
 
@@ -145,6 +169,9 @@ public class GameEditViewModelTests
         Assert.Null(viewModel.SelectedExePathOption);
         Assert.False(viewModel.IsManual);
         Assert.False(viewModel.IsHidden);
+        Assert.False(viewModel.CanAutoFix);
+        Assert.False(viewModel.ImagePathRequiresAttention);
+        Assert.False(viewModel.ExePathRequiresAttention);
     }
 
     [Fact]
@@ -168,6 +195,8 @@ public class GameEditViewModelTests
             _messenger,
             _filePicker,
             _clipboardService,
+            _dispatcherQueue,
+            _path,
             _logger,
             adrenalineGameId: gameInfo.Id);
 
@@ -182,6 +211,9 @@ public class GameEditViewModelTests
         Assert.Equal(GameEditViewModel.CustomExePathOption, viewModel.SelectedExePathOption);
         Assert.Equal(gameInfo.IsManual, viewModel.IsManual);
         Assert.Equal(gameInfo.IsHidden, viewModel.IsHidden);
+        Assert.False(viewModel.CanAutoFix);
+        Assert.False(viewModel.ImagePathRequiresAttention);
+        Assert.False(viewModel.ExePathRequiresAttention);
     }
 
     [Fact]
@@ -195,8 +227,8 @@ public class GameEditViewModelTests
             null,
             @"Assets\Logo.png",
             true,
-            @"Game.exe",
-            ["gamelauncherhelper.exe", @"Game.exe"]);
+            "Game.exe",
+            ["gamelauncherhelper.exe", "Game.exe"]);
         var expectedOptions = appInfo.ExecutablePaths
             .Select(x => new ComboBoxOption<string>(Path.Combine(appInfo.InstalledPath, x), $@"\{x}"))
             .Concat([GameEditViewModel.CustomExePathOption]);
@@ -217,6 +249,8 @@ public class GameEditViewModelTests
             _messenger,
             _filePicker,
             _clipboardService,
+            _dispatcherQueue,
+            _path,
             _logger,
             adrenalineGameId: gameInfo.Id);
 
@@ -229,6 +263,9 @@ public class GameEditViewModelTests
         Assert.Equal(gameInfo.ExePath, viewModel.ExePath);
         Assert.Equal(expectedOptions, viewModel.ExePathOptions);
         Assert.Equal(viewModel.ExePathOptions.Single(x => x.Value == gameInfo.ExePath), viewModel.SelectedExePathOption);
+        Assert.False(viewModel.CanAutoFix);
+        Assert.False(viewModel.ImagePathRequiresAttention);
+        Assert.False(viewModel.ExePathRequiresAttention);
     }
 
     [Fact]
@@ -240,6 +277,8 @@ public class GameEditViewModelTests
             _messenger,
             _filePicker,
             _clipboardService,
+            _dispatcherQueue,
+            _path,
             _logger,
             adrenalineGameId: Guid.NewGuid());
 
@@ -251,19 +290,283 @@ public class GameEditViewModelTests
         Assert.Null(viewModel.ExePath);
         Assert.Empty(viewModel.ExePathOptions);
         Assert.Null(viewModel.SelectedExePathOption);
+        Assert.False(viewModel.CanAutoFix);
+        Assert.False(viewModel.ImagePathRequiresAttention);
+        Assert.False(viewModel.ExePathRequiresAttention);
     }
 
-    [InlineData(null, false)]
-    [InlineData("", false)]
-    [InlineData(@"C:\Path\Image.png", true)]
-    [Theory]
-    public void SetImagePath_HasImagePathUpdates(string? path, bool expected)
+    [Fact]
+    public void Ctor_IsPackagedAppWithNoPaths_CannotAutoFix()
     {
-        _viewModel.ImagePath = path;
+        // Arrange
+        var appInfo = new PackagedAppInfo("Test Game",
+            "Package!App",
+            @"C:\InstalledLocation\Package_v2",
+            DateTimeOffset.MinValue,
+            null,
+            @"Assets\Logo.png",
+            true,
+            "Game.exe",
+            ["gamelauncherhelper.exe", "Game.exe"]);
+        var expectedOptions = appInfo.ExecutablePaths
+            .Select(x => new ComboBoxOption<string>(Path.Combine(appInfo.InstalledPath, x), $@"\{x}"))
+            .Concat([GameEditViewModel.CustomExePathOption]);
+        _packagedAppsService.GetInfoAsync(appInfo.AppUserModelId).Returns(appInfo);
+        var gameInfo = new AdrenalineGameInfo(Guid.Parse("9721c8ae-b162-4e64-bbc6-eac6d933b711"),
+            "Test Display Name",
+            string.Empty,
+            appInfo.AppUserModelId,
+            string.Empty,
+            true,
+            true);
+        _adrenalineGamesDataService.GamesData.Returns([gameInfo]);
+        _packagedAppsService.GetInfoAsync(gameInfo.CommandLine).Returns(appInfo);
+        _path.Exists(gameInfo.ImagePath).Returns(false);
 
-        var actual = _viewModel.HasImagePath;
+        // Act
+        var viewModel = new GameEditViewModel(_packagedAppsService,
+            _qualifiedFileResolver,
+            _adrenalineGamesDataService,
+            _messenger,
+            _filePicker,
+            _clipboardService,
+            _dispatcherQueue,
+            _path,
+            _logger,
+            adrenalineGameId: gameInfo.Id);
 
-        Assert.Equal(expected, actual);
+        // Assert
+        Assert.Equal("Edit Game", viewModel.Title);
+        Assert.Equal(gameInfo.Id, viewModel.Id);
+        Assert.Equal(gameInfo.DisplayName, viewModel.DisplayName);
+        Assert.Equal(gameInfo.CommandLine, viewModel.Command);
+        Assert.Equal(gameInfo.ImagePath, viewModel.ImagePath);
+        Assert.Equal(gameInfo.ExePath, viewModel.ExePath);
+        Assert.Equal(expectedOptions, viewModel.ExePathOptions);
+        Assert.Equal(GameEditViewModel.CustomExePathOption, viewModel.SelectedExePathOption);
+        Assert.False(viewModel.CanAutoFix);
+        Assert.False(viewModel.ImagePathRequiresAttention);
+        Assert.False(viewModel.ExePathRequiresAttention);
+    }
+
+    [Fact]
+    public void Ctor_IsPackagedAppWithBrokenImagePathAndAutoFixCandidate_CanAutoFixImagePath()
+    {
+        // Arrange
+        var appInfo = new PackagedAppInfo("Test Game",
+            "Package!App",
+            @"C:\InstalledLocation\Package_v2",
+            DateTimeOffset.MinValue,
+            null,
+            @"Assets\Logo.png",
+            true,
+            "Game.exe",
+            ["gamelauncherhelper.exe", "Game.exe"]);
+        var expectedOptions = appInfo.ExecutablePaths
+            .Select(x => new ComboBoxOption<string>(Path.Combine(appInfo.InstalledPath, x), $@"\{x}"))
+            .Concat([GameEditViewModel.CustomExePathOption]);
+        _packagedAppsService.GetInfoAsync(appInfo.AppUserModelId).Returns(appInfo);
+        var gameInfo = new AdrenalineGameInfo(Guid.Parse("9721c8ae-b162-4e64-bbc6-eac6d933b711"),
+            "Test Display Name",
+            @"C:\InstalledLocation\Package_v1\Image.png",
+            appInfo.AppUserModelId,
+            @"C:\InstalledLocation\Package_v1\Game.exe",
+            true,
+            true);
+        _adrenalineGamesDataService.GamesData.Returns([gameInfo]);
+        _packagedAppsService.GetInfoAsync(gameInfo.CommandLine).Returns(appInfo);
+        _path.Exists(Arg.Is<string>(x => x.EndsWith("Image.png"))).Returns(false);
+        _path.Exists(@"C:\InstalledLocation\Package_v2\Image.png").Returns(true);
+
+        // Act
+        var viewModel = new GameEditViewModel(_packagedAppsService,
+            _qualifiedFileResolver,
+            _adrenalineGamesDataService,
+            _messenger,
+            _filePicker,
+            _clipboardService,
+            _dispatcherQueue,
+            _path,
+            _logger,
+            adrenalineGameId: gameInfo.Id);
+
+        // Assert
+        Assert.Equal("Edit Game", viewModel.Title);
+        Assert.Equal(gameInfo.Id, viewModel.Id);
+        Assert.Equal(gameInfo.DisplayName, viewModel.DisplayName);
+        Assert.Equal(gameInfo.CommandLine, viewModel.Command);
+        Assert.Equal(gameInfo.ImagePath, viewModel.ImagePath);
+        Assert.Equal(gameInfo.ExePath, viewModel.ExePath);
+        Assert.Equal(expectedOptions, viewModel.ExePathOptions);
+        Assert.Equal(GameEditViewModel.CustomExePathOption, viewModel.SelectedExePathOption);
+        Assert.True(viewModel.CanAutoFix);
+        Assert.True(viewModel.ImagePathRequiresAttention);
+        Assert.False(viewModel.ExePathRequiresAttention);
+    }
+
+    [Fact]
+    public void Ctor_IsPackagedAppWithBrokenImagePathButNoAutoFixCandidate_CannotAutoFixImagePath()
+    {
+        // Arrange
+        var appInfo = new PackagedAppInfo("Test Game",
+            "Package!App",
+            @"C:\InstalledLocation\Package_v2",
+            DateTimeOffset.MinValue,
+            null,
+            @"Assets\Logo.png",
+            true,
+            "Game.exe",
+            ["gamelauncherhelper.exe", "Game.exe"]);
+        var expectedOptions = appInfo.ExecutablePaths
+            .Select(x => new ComboBoxOption<string>(Path.Combine(appInfo.InstalledPath, x), $@"\{x}"))
+            .Concat([GameEditViewModel.CustomExePathOption]);
+        _packagedAppsService.GetInfoAsync(appInfo.AppUserModelId).Returns(appInfo);
+        var gameInfo = new AdrenalineGameInfo(Guid.Parse("9721c8ae-b162-4e64-bbc6-eac6d933b711"),
+            "Test Display Name",
+            @"C:\InstalledLocation\Package_v1\Image.png",
+            appInfo.AppUserModelId,
+            @"C:\InstalledLocation\Package_v1\Game.exe",
+            true,
+            true);
+        _adrenalineGamesDataService.GamesData.Returns([gameInfo]);
+        _packagedAppsService.GetInfoAsync(gameInfo.CommandLine).Returns(appInfo);
+        _path.Exists(Arg.Is<string>(x => x.EndsWith("Image.png"))).Returns(false);
+
+        // Act
+        var viewModel = new GameEditViewModel(_packagedAppsService,
+            _qualifiedFileResolver,
+            _adrenalineGamesDataService,
+            _messenger,
+            _filePicker,
+            _clipboardService,
+            _dispatcherQueue,
+            _path,
+            _logger,
+            adrenalineGameId: gameInfo.Id);
+
+        // Assert
+        Assert.Equal("Edit Game", viewModel.Title);
+        Assert.Equal(gameInfo.Id, viewModel.Id);
+        Assert.Equal(gameInfo.DisplayName, viewModel.DisplayName);
+        Assert.Equal(gameInfo.CommandLine, viewModel.Command);
+        Assert.Equal(gameInfo.ImagePath, viewModel.ImagePath);
+        Assert.Equal(gameInfo.ExePath, viewModel.ExePath);
+        Assert.Equal(expectedOptions, viewModel.ExePathOptions);
+        Assert.Equal(GameEditViewModel.CustomExePathOption, viewModel.SelectedExePathOption);
+        Assert.False(viewModel.CanAutoFix);
+        Assert.True(viewModel.ImagePathRequiresAttention);
+        Assert.False(viewModel.ExePathRequiresAttention);
+    }
+
+    [Fact]
+    public void Ctor_IsPackagedAppWithBrokenExePathAndAutoFixCandidate_CanAutoFixExePath()
+    {
+        // Arrange
+        var appInfo = new PackagedAppInfo("Test Game",
+            "Package!App",
+            @"C:\InstalledLocation\Package_v2",
+            DateTimeOffset.MinValue,
+            null,
+            @"Assets\Logo.png",
+            true,
+            "Game.exe",
+            ["gamelauncherhelper.exe", "Game.exe"]);
+        var expectedOptions = appInfo.ExecutablePaths
+            .Select(x => new ComboBoxOption<string>(Path.Combine(appInfo.InstalledPath, x), $@"\{x}"))
+            .Concat([GameEditViewModel.CustomExePathOption]);
+        _packagedAppsService.GetInfoAsync(appInfo.AppUserModelId).Returns(appInfo);
+        var gameInfo = new AdrenalineGameInfo(Guid.Parse("9721c8ae-b162-4e64-bbc6-eac6d933b711"),
+            "Test Display Name",
+            @"C:\InstalledLocation\Package_v1\Image.png",
+            appInfo.AppUserModelId,
+            @"C:\InstalledLocation\Package_v1\Game.exe",
+            true,
+            true);
+        _adrenalineGamesDataService.GamesData.Returns([gameInfo]);
+        _adrenalineGamesDataService.GamesData.Returns([gameInfo]);
+        _packagedAppsService.GetInfoAsync(gameInfo.CommandLine).Returns(appInfo);
+        _path.Exists(Arg.Is<string>(x => x.EndsWith("Game.exe"))).Returns(false);
+        _path.Exists(@"C:\InstalledLocation\Package_v2\Game.exe").Returns(true);
+
+        // Act
+        var viewModel = new GameEditViewModel(_packagedAppsService,
+            _qualifiedFileResolver,
+            _adrenalineGamesDataService,
+            _messenger,
+            _filePicker,
+            _clipboardService,
+            _dispatcherQueue,
+            _path,
+            _logger,
+            adrenalineGameId: gameInfo.Id);
+
+        // Assert
+        Assert.Equal("Edit Game", viewModel.Title);
+        Assert.Equal(gameInfo.Id, viewModel.Id);
+        Assert.Equal(gameInfo.DisplayName, viewModel.DisplayName);
+        Assert.Equal(gameInfo.CommandLine, viewModel.Command);
+        Assert.Equal(gameInfo.ImagePath, viewModel.ImagePath);
+        Assert.Equal(gameInfo.ExePath, viewModel.ExePath);
+        Assert.Equal(expectedOptions, viewModel.ExePathOptions);
+        Assert.Equal(GameEditViewModel.CustomExePathOption, viewModel.SelectedExePathOption);
+        Assert.True(viewModel.CanAutoFix);
+        Assert.False(viewModel.ImagePathRequiresAttention);
+        Assert.True(viewModel.ExePathRequiresAttention);
+    }
+
+    [Fact]
+    public void Ctor_IsPackagedAppWithBrokenExePathButNoAutoFixCandidate_CannotAutoFixExePath()
+    {
+        // Arrange
+        var appInfo = new PackagedAppInfo("Test Game",
+            "Package!App",
+            @"C:\InstalledLocation\Package_v2",
+            DateTimeOffset.MinValue,
+            null,
+            @"Assets\Logo.png",
+            true,
+            "Game.exe",
+            ["gamelauncherhelper.exe", "Game.exe"]);
+        var expectedOptions = appInfo.ExecutablePaths
+            .Select(x => new ComboBoxOption<string>(Path.Combine(appInfo.InstalledPath, x), $@"\{x}"))
+            .Concat([GameEditViewModel.CustomExePathOption]);
+        _packagedAppsService.GetInfoAsync(appInfo.AppUserModelId).Returns(appInfo);
+        var gameInfo = new AdrenalineGameInfo(Guid.Parse("9721c8ae-b162-4e64-bbc6-eac6d933b711"),
+            "Test Display Name",
+            @"C:\InstalledLocation\Package_v1\Image.png",
+            appInfo.AppUserModelId,
+            @"C:\InstalledLocation\Package_v1\Game.exe",
+            true,
+            true);
+        _adrenalineGamesDataService.GamesData.Returns([gameInfo]);
+        _adrenalineGamesDataService.GamesData.Returns([gameInfo]);
+        _packagedAppsService.GetInfoAsync(gameInfo.CommandLine).Returns(appInfo);
+        _path.Exists(Arg.Is<string>(x => x.EndsWith("Game.exe"))).Returns(false);
+
+        // Act
+        var viewModel = new GameEditViewModel(_packagedAppsService,
+            _qualifiedFileResolver,
+            _adrenalineGamesDataService,
+            _messenger,
+            _filePicker,
+            _clipboardService,
+            _dispatcherQueue,
+            _path,
+            _logger,
+            adrenalineGameId: gameInfo.Id);
+
+        // Assert
+        Assert.Equal("Edit Game", viewModel.Title);
+        Assert.Equal(gameInfo.Id, viewModel.Id);
+        Assert.Equal(gameInfo.DisplayName, viewModel.DisplayName);
+        Assert.Equal(gameInfo.CommandLine, viewModel.Command);
+        Assert.Equal(gameInfo.ImagePath, viewModel.ImagePath);
+        Assert.Equal(gameInfo.ExePath, viewModel.ExePath);
+        Assert.Equal(expectedOptions, viewModel.ExePathOptions);
+        Assert.Equal(GameEditViewModel.CustomExePathOption, viewModel.SelectedExePathOption);
+        Assert.False(viewModel.CanAutoFix);
+        Assert.False(viewModel.ImagePathRequiresAttention);
+        Assert.True(viewModel.ExePathRequiresAttention);
     }
 
     [InlineData(null, null, null)]
@@ -295,8 +598,8 @@ public class GameEditViewModelTests
             null,
             @"Assets\Logo.png",
             true,
-            @"Game.exe",
-            [@"Game.exe"]);
+            "Game.exe",
+            ["Game.exe"]);
         _packagedAppsService.GetInfoAsync(appInfo.AppUserModelId).Returns(appInfo);
         _qualifiedFileResolver.GetPath(appInfo.InstalledPath, appInfo.Square150x150Logo!)
             .Returns(Path.Combine(appInfo.InstalledPath, appInfo.Square150x150Logo!));
@@ -308,6 +611,8 @@ public class GameEditViewModelTests
             _messenger,
             _filePicker,
             _clipboardService,
+            _dispatcherQueue,
+            _path,
             _logger,
             appInfo.AppUserModelId)
         {
@@ -421,5 +726,71 @@ public class GameEditViewModelTests
         _viewModel.CopyImagePathCommand.Execute(null);
 
         _clipboardService.Received(1).SetText(_viewModel.ImagePath);
+    }
+
+    [Fact]
+    public void AutoFix_NoAutoFixCandidates_DoesNothing()
+    {
+        var expectedImagePath = @"C:\Path\Image.png";
+        var expectedExePath = @"C:\Path\Game.exe";
+        _viewModel.ImagePath = expectedImagePath;
+        _viewModel.ExePath = expectedExePath;
+
+        _viewModel.AutoFixCommand.Execute(null);
+
+        Assert.Equal(expectedImagePath, _viewModel.ImagePath);
+        Assert.Equal(expectedExePath, _viewModel.ExePath);
+        Assert.False(_viewModel.CanAutoFix);
+    }
+
+    [Fact]
+    public void AutoFix_HasAutoFixCandidates_UpdatesPaths()
+    {
+        // Arrange
+        var expectedImagePath = @"C:\InstalledLocation\Package_v2\Image.png";
+        var expectedExePath = @"C:\InstalledLocation\Package_v2\Game.exe";
+        var appInfo = new PackagedAppInfo("Test Game",
+            "Package!App",
+            @"C:\InstalledLocation\Package_v2",
+            DateTimeOffset.MinValue,
+            null,
+            @"Assets\Logo.png",
+            true,
+            "Game.exe",
+            ["gamelauncherhelper.exe", "Game.exe"]);
+        var expectedOptions = appInfo.ExecutablePaths
+            .Select(x => new ComboBoxOption<string>(Path.Combine(appInfo.InstalledPath, x), $@"\{x}"))
+            .Concat([GameEditViewModel.CustomExePathOption]);
+        _packagedAppsService.GetInfoAsync(appInfo.AppUserModelId).Returns(appInfo);
+        var gameInfo = new AdrenalineGameInfo(Guid.Parse("9721c8ae-b162-4e64-bbc6-eac6d933b711"),
+            "Test Display Name",
+            @"C:\InstalledLocation\Package_v1\Image.png",
+            appInfo.AppUserModelId,
+            @"C:\InstalledLocation\Package_v1\Game.exe",
+            true,
+            true);
+        _adrenalineGamesDataService.GamesData.Returns([gameInfo]);
+        _packagedAppsService.GetInfoAsync(gameInfo.CommandLine).Returns(appInfo);
+        _path.Exists(Arg.Is<string>(x => x.EndsWith("Image.png") || x.EndsWith("Game.exe"))).Returns(false);
+        _path.Exists(expectedImagePath).Returns(true);
+        _path.Exists(expectedExePath).Returns(true);
+        var viewModel = new GameEditViewModel(_packagedAppsService,
+            _qualifiedFileResolver,
+            _adrenalineGamesDataService,
+            _messenger,
+            _filePicker,
+            _clipboardService,
+            _dispatcherQueue,
+            _path,
+            _logger,
+            adrenalineGameId: gameInfo.Id);
+
+        // Act
+        viewModel.AutoFixCommand.Execute(null);
+
+        // Assert
+        Assert.Equal(expectedImagePath, viewModel.ImagePath);
+        Assert.Equal(expectedExePath, viewModel.ExePath);
+        Assert.False(_viewModel.CanAutoFix);
     }
 }


### PR DESCRIPTION
- Show loading indicator when page is not ready.
- Alert when paths are invalid.
- Allow one click fix when updated package paths are resolvable.
- Hide package path combobox when there are none.